### PR TITLE
3 add safe guards and warnings when requesting more then 10k entries

### DIFF
--- a/src/mapineqpy/data.py
+++ b/src/mapineqpy/data.py
@@ -17,7 +17,8 @@ def data(
         level (str): The NUTS level ("0", "1", "2", "3").
         x_filters (dict): Filters for the x variable as a dictionary of field-value pairs.
         y_filters (dict, optional): Filters for the y variable as a dictionary of field-value pairs. Default is None.
-        limit (int): Maximum number of results to return. Default is 2500.
+        limit (int): Maximum number of results to return. Default is 2500. This default should be enough for most uses, 
+                     as it is well above the number of NUTS 3 regions in the EU. The maximum allowed by the API is 10,000.
 
     Returns:
         pd.DataFrame: A DataFrame containing univariate or bivariate data with the following columns:
@@ -71,11 +72,13 @@ def data(
         raise ValueError("`year` must be an integer.")
     if y_source is not None and not isinstance(y_source, str):
         raise ValueError("`y_source` must be a string if provided.")
+    if not isinstance(limit, int) or not (1 <= limit <= 10000):
+        raise ValueError("`limit` must be an integer between 1 and 10,000.")
 
     # Build JSON for X filters
     x_conditions = [{"field": key, "value": value} for key, value in x_filters.items()]
     x_json = {"source": x_source, "conditions": x_conditions}
-    x_json_string = json.dumps(x_json, separators=(",", ":"))  # Compact JSON format
+    x_json_string = json.dumps(x_json, separators=(",", ":"))
 
     # Check if bivariate (Y filters provided)
     y_json_string = None


### PR DESCRIPTION
The `mi.data()` function has been enhanced to perform duplicate and error checks on the data retrieved from the API. In the event of duplicates or errors, it identifies the specific variable for which insufficient filters were applied and provides informative error messages with suggestions for improvement. Examples of this functionality are provided below.

# test - duplicates only in ghs_smod
```py
import mapineqpy as mi

x_source = "ghs_smod"
y_source = "ookla"
x_filters = {}  # An empty dictionary for x_filters
y_filters = {"quarter": "4", "network_type": "fixed", "direction": "download"}
year = 2020
level = "3"
limit = 2500
xy = mi.data(x_source, y_source, year = year, level = level, x_filters = x_filters, y_filters = y_filters, limit = limit)
```

```
ValueError: The API returned duplicate values for some geographic regions. This may indicate that not all necessary filters were specified.

For the 'x' variable (source: 'ghs_smod'): The following filter fields (with multiple available options) were not specified: indicator. You can review available filters by running:
  mi.source_filters(source_name='ghs_smod', year=2020, level='3')
```


# test - duplicates only in ookla
```py
import mapineqpy as mi

x_source = "ghs_smod"
y_source = "ookla"
x_filters = {"indicator": "WATER GRID CELL"}
y_filters = {"quarter": "4", "network_type": "fixed"}
year = 2020
level = "3"
limit = 2500
xy = mi.data(x_source, y_source, year = year, level = level, x_filters = x_filters, y_filters = y_filters, limit = limit)
```

```
ValueError: The API returned duplicate values for some geographic regions. This may indicate that not all necessary filters were specified.

For the 'y' variable (source: 'ookla'): The following filter fields (with multiple available options) were not specified: direction. You can review available filters by running:
  mi.source_filters(source_name='ookla', year=2020, level='3')
```


# test - duplicates in both data sources

```py
import mapineqpy as mi

x_source = "ghs_smod"
y_source = "ookla"
x_filters = {}
y_filters = {"quarter": "4", "network_type": "fixed"}
year = 2020
level = "3"
limit = 2500
xy = mi.data(x_source, y_source, year = year, level = level, x_filters = x_filters, y_filters = y_filters, limit = limit)
```

```
ValueError: The API returned duplicate values for some geographic regions. This may indicate that not all necessary filters were specified.

For the 'x' variable (source: 'ghs_smod'): The following filter fields (with multiple available options) were not specified: indicator. You can review available filters by running:
  mi.source_filters(source_name='ghs_smod', year=2020, level='3')

For the 'y' variable (source: 'ookla'): The following filter fields (with multiple available options) were not specified: direction. You can review available filters by running:
  mi.source_filters(source_name='ookla', year=2020, level='3')
```



# test - multiple variables for a single indicator

```py
import mapineqpy as mi

mi.data(
  x_source = "TGS00010",
  year = 2020,
  level = "2"
)
```


```
ValueError: The API returned duplicate values for some geographic regions. This may indicate that not all necessary filters were specified.

For the 'x' variable (source: 'TGS00010'): The following filter fields (with multiple available options) were not specified: sex, isced11. You can review available filters by running:
  mi.source_filters(source_name='TGS00010', year=2020, level='2')
```
