### PR TITLE
implement debug option to skip filter checks

### DIFF
--- a/src/mapineqpy/__init__.py
+++ b/src/mapineqpy/__init__.py
@@ -4,6 +4,7 @@ from .levels import nuts_levels
 from .sources import sources, source_coverage
 from .source_filters import source_filters
 from .data import data
+from .options import options
 
 __all__ = [
     "nuts_levels",

--- a/src/mapineqpy/data.py
+++ b/src/mapineqpy/data.py
@@ -3,7 +3,7 @@ import pandas as pd
 import json
 from mapineqpy.config import BASE_API_ENDPOINT, USER_AGENT
 from mapineqpy import source_filters
-
+from mapineqpy.options import options
 
 def data(
     x_source, y_source=None, year=None, level=None, x_filters=None, y_filters=None, limit=2500
@@ -131,7 +131,7 @@ def data(
         y_issue = (distinct_y > 1).any()
 
     # Only perform additional filter checking if duplicate geos exist.
-    if x_issue or y_issue:
+    if not options.get("skip_filter_check", False):
         missing_x_filters = set()
         if x_issue:
             # Query available filters for x_source

--- a/src/mapineqpy/options.py
+++ b/src/mapineqpy/options.py
@@ -1,0 +1,3 @@
+options = {
+    "skip_filter_check": False,  # Default: perform filter checks
+}


### PR DESCRIPTION
Classic code:

```py
import mapineqpy as mi

mi.data(
  x_source = "TGS00010",
  year = 2020,
  level = "2"
)
```

Results in:

```py
ValueError: The API returned duplicate values for some geographic regions. This may indicate that not all necessary filters were specified.

For the 'x' variable (source: 'TGS00010'): The following filter fields (with multiple available options) were not specified: sex, isced11. You can review available filters by running:
  mi.source_filters(source_name='TGS00010', year=2020, level='2')
Cell In[2], line 1
----> 1 mi.data(
      2   x_source = "TGS00010",
      3   year = 2020,
      4   level = "2"
      5 )
```

With new option:

```py
mi.options["skip_filter_check"] = True
```

It is possible to disable the filter check and get the data from the API anyway:

```py
mi.data(
  x_source = "TGS00010",
  year = 2020,
  level = "2"
)
```

```

geo | geo_name | geo_source | geo_year | x_year | x
-- | -- | -- | -- | -- | --
AL01 | Veri | NUTS | 2021 | 2020 | NaN
AL02 | Qender | NUTS | 2021 | 2020 | NaN
AL03 | Jug | NUTS | 2021 | 2020 | NaN
AT11 | Burgenland | NUTS | 2021 | 2020 | 4.5
AT11 | Burgenland | NUTS | 2021 | 2020 | NaN
... | ... | ... | ... | ... | ...
FRY2 | Martinique | NUTS | 2021 | 2020 | NaN
FRY2 | Martinique | NUTS | 2021 | 2020 | 13.7
FRY2 | Martinique | NUTS | 2021 | 2020 | 17.1
FRY2 | Martinique | NUTS | 2021 | 2020 | NaN
FRY2 | Martinique | NUTS | 2021 | 2020 | NaN
```
